### PR TITLE
docs: add RFD for linux job worker service

### DIFF
--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -182,7 +182,7 @@ The API is a gRPC service written in Golang. The API acts as a wrapper around th
 ### How the server works
 
 Note: gRPC handlers each run in their own goroutine. Out of the box, this enables the server to support concurrent requests.
-The handlers must be safe for concurrent use, such as using a [sync.Map](https://pkg.go.dev/sync#Map) to store jobs.
+The handlers must be safe for concurrent use, such as using a map with a mutex to store jobs.
 
 #### Starting a new job
 

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -310,7 +310,10 @@ It is expected that `JobExecutorPath` will add the pid of the process to the cgr
 > as `JobExecutorPath`.
 
 The `JobExecutorPath` may seem odd, but this enables a "hook" to add the new process's PID to the cgroup before actually executing
-the desired command.
+the desired command and mounting a new `proc` file system.
+
+> Note: `Job.Start` might be able to configure [UseCgroupFD and CgroupFD](https://pkg.go.dev/syscall#SysProcAttr) so
+> the binary doesn't have to add the PID to the cgroup's `cgroup.procs` file.
 
 ##### func (*Job) Start() error
 

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -482,3 +482,6 @@ Create a few end-to-end tests to verify some behaviors like:
 1. Demonstrate starting a job, streaming the job output, and validating the stream completes when the process completes.
 1. Demonstrate a user may not interact with another user's job.
 1. Demonstrate a job may not make network requests.
+1. Demonstrate cgroups' limits are being enforced by running commands such as:
+   - `dd if=/dev/zero of=/tmp/test bs=512M count=1` to verify io.max
+   - `sha1sum /dev/random` to verify cpu.limit

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -360,8 +360,11 @@ It is expected that `JobExecutorPath` will mount a new proc filesystem and then 
 > as `JobExecutorPath`.
 
 The `JobExecutorPath` may seem odd, but this enables a "hook" to create and mount a new proc filesystem before forking + executing the desired command with any arguments.
+This technique enables process execution within the newly created mount namespace to mount a new proc filesystem. Without the `JobExecutorPath`, if the user's command
+was executed directly, then the user's command would still use the host's proc filesystem.
 
-The library should provide an exported function(s) that can mount and unmount a new proc file system.
+The library should provide an exported function(s) that can mount and unmount a new proc file system. The library should also provide an exported function
+that can handle signals such as `SIGTERM` and send `SIGTERM` to the process it's running (user's command).
 
 ##### func (*Job) Start() error
 

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -230,6 +230,12 @@ The API treats the client's common name (CN) in the certificate as the user's id
 
 A client/user may not interact with a job not created by them in any way. No querying, streaming, or stopping of another user's job is allowed.
 
+Each handler may retrieve the user's identity by:
+
+1. extracting the peer from the context
+1. extracting the certificate from the peer's auth information
+1. looking up the common name in the certificate
+
 #### Protobuf
 
 The proposed protobuf file for the client/server is as follows:

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -315,6 +315,8 @@ the desired command and mounting a new `proc` file system.
 > Note: `Job.Start` might be able to configure [UseCgroupFD and CgroupFD](https://pkg.go.dev/syscall#SysProcAttr) so
 > the binary doesn't have to add the PID to the cgroup's `cgroup.procs` file.
 
+The library should provide an exported function(s) that can mount and unmount a new proc file system.
+
 ##### func (*Job) Start() error
 
 `Start` creates a configured [exec.Cmd](https://pkg.go.dev/os/exec#Cmd).

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -309,7 +309,7 @@ the desired command.
 
 `Start` will return an error if the `Job` was provided a `JobConfig` with zero values for any of the fields, except `Arguments`.
 
-The configured `exec.Cmd` will isolate the process by setting clone and share flags for creating new mount, pid, and network namespaces.
+The configured `exec.Cmd` will isolate the process by setting clone and unshare flags for creating new mount, pid, and network namespaces.
 
 `Start` will also create a new cgroup for the job and set the CPU, memory, and IO limits. It will be up to the `jobExecutorPath` to append the PID to the cgroup's `cgroup.procs` file as described above.
 

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -390,7 +390,6 @@ The library should provide an exported function(s) that can mount and unmount a 
 
 As described above, `Start`'s configured `exec.Cmd` will execute `jobExecutorPath`. It is expected that `jobExecutorPath` is a binary that will do the following:
 
-1. create a new directory to mount a new proc filesystem such as `/tmp/proc-<uuid>`
 1. mount a new proc filesystem to limit the process's view of the host's processes
 1. execute the provided `command` and `arguments` using [exec.Cmd](https://pkg.go.dev/os/exec#Cmd), which forks and executes the command
    - This means that `jobExecutorPath` is PID 1, while the user's command is a child process of `jobExecutorPath`

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -181,6 +181,9 @@ The API is a gRPC service written in Golang. The API acts as a wrapper around th
 
 ### How the server works
 
+Note: gRPC handlers each run in their own goroutine. Out of the box, this enables the server to support concurrent requests.
+The handlers must be safe for concurrent use, such as using a [sync.Map](https://pkg.go.dev/sync#Map) to store jobs.
+
 #### Starting a new job
 
 When the server receives a request to start a new job, it will:
@@ -285,6 +288,9 @@ A library written in Golang supports running an arbitrary Linux process in isola
 
 This library should know nothing about the client or API. It should be able to be used in any Golang program and treated as
 a public library.
+
+Jobs should be safe for concurrent use. Consider a mutex to handle concurrent changes to job's state such as stop being invoked
+multiple times concurrently.
 
 #### Process isolation
 

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -330,6 +330,7 @@ The configured `exec.Cmd` will isolate the process by setting clone and unshare 
 The configured `exec.Cmd` will execute `jobExecutorPath`. It is expected that `jobExecutorPath` is a binary that will do the following:
 
 - append the PID to the provided `cgroup.procs` file
+   - This might end up being handled by [UseCgroupFD and CgroupFD](https://pkg.go.dev/syscall#SysProcAttr), which removes the need to provide a path to `cgroup.procs`
 - mount a new proc filesystem
 - execute the provided `command` and `arguments`
 

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -373,7 +373,10 @@ It is okay to call `Stream` on a job that has not been started. The channel will
 
 ##### func (*Job) Stop() error
 
-`Stop` will kill the process.
+`Stop` will kill the process by sending a SIGKILL signal to the process via [exec.Cmd.Process.Kill](https://pkg.go.dev/os/exec#Cmd.Process).
+
+> Note: a future enhancement could be to send a SIGTERM signal first and then a SIGKILL signal after a timeout if the process has not terminated. This would allow the process to gracefully shutdown if it can.
+> As part of this, `JobExecutorPath` would need to handle SIGTERM signals and forward them to the user's command.
 
 Since the process is PID 1 in the new pid namespace, killing it will kill all other spawned process in the pid namespace.
 

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -354,9 +354,9 @@ It is expected that the config's `JobExecutorPath` is a binary that will execute
 
 It is expected that `JobExecutorPath` will mount a new proc filesystem and then fork+execute the user's command with any arguments.
 
-> Note: `JobExecutorPath` may be a new binary entirely created from this design for the library to use. Eventually, it may make more
-> sense for the server binary to be a compatible `JobExecutorPath` that the library uses. This way to deploy the server requires only the one
-> server binary instead of the server binary and the `JobExecutorPath` binary. The server could provide `/proc/self/exe` to the library
+> Note: `JobExecutorPath` will be a new binary entirely created from this design for the library to use. Eventually, the server's binary
+> will be a compatible `JobExecutorPath` that the library can be instructed to use. This way to deploy the server requires only the one
+> server binary instead of the server binary and the `JobExecutorPath` binary. The server can then provide `/proc/self/exe` (itself) to the library
 > as `JobExecutorPath`.
 
 The `JobExecutorPath` may seem odd, but this enables a "hook" to create and mount a new proc filesystem before forking + executing the desired command with any arguments.

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -197,6 +197,8 @@ A client/user may not interact with a job not created by them in any way. No que
 
 #### Protobuf
 
+The proposed protobuf file for the client/server is as follows:
+
 ```proto
 syntax = "proto3";
 

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -483,5 +483,5 @@ Create a few end-to-end tests to verify some behaviors like:
 1. Demonstrate a user may not interact with another user's job.
 1. Demonstrate a job may not make network requests.
 1. Demonstrate cgroups' limits are being enforced by running commands such as:
-   - `dd if=/dev/zero of=/tmp/test bs=512M count=1` to verify io.max
-   - `sha1sum /dev/random` to verify cpu.limit
+   - `dd if=/dev/zero of=/tmp/test bs=512M count=1` to verify io.max (`dd` outputs rough approximations of read and write speeds)
+   - `sha1sum /dev/random` to verify cpu.limit (while it's running, can use something like `ps -p $(pgrep sha1sum) -o %cpu` to verify CPU usage)

--- a/rfd/0001-linux-job-worker-service.md
+++ b/rfd/0001-linux-job-worker-service.md
@@ -1,0 +1,406 @@
+---
+authors: Dustin Specker
+state: draft
+---
+
+# RFD 1 - Linux Job Worker Service
+
+## What
+
+Design and API for starting arbitrary Linux processes (jobs), streaming job output, querying job status, and stopping
+jobs.
+
+## Why
+
+A user may want to run a variety of Linux processes on a machine, such as:
+
+- short-lived commands like `df -h`
+- long-lived commands like `sleep 1000`
+
+A job's process should be isolated for security purposes and to prevent disrupting
+other running workloads.
+
+A user may want to query the status of a job to determine if it's still running or
+stream the process's output as it runs.
+
+## User Stories
+
+A user wants to run a short-lived command such as `df -h`, verify the command ran successfully, and view the entirety of the command's output.
+
+A user wants to run a long-lived command such as `sleep 1000`, verify the command is running, and stream the command's output from when it started to current output.
+
+A user wants to identify why a job failed to run and view the error message by checking the status of the job.
+
+A user starts a long-lived job and decides they no longer need it. The user wants to stop the job. The user later wants to view
+the job's output afterward.
+
+## Details
+
+The Linux job worker service is made up of the following components:
+
+- a library to run isolated processes with resource limits
+- a gRPC API to manage jobs and invoke processes using the above library
+- a CLI to communicate with the API via gRPC using mTLS for authentication and authorization
+
+### Assumptions
+
+- only support a single Linux 64-bit machine
+- a new enough kernel to support cgroups v2 and namespaces
+- cgroups v2 is set up on the machine
+- the machine has enough memory to hold all running jobs' stdout and stderr in memory
+
+### Out of Scope
+
+- high availability of the server
+- observability of the server
+- role based access control
+- restarting jobs
+- other Linux namespaces such as UTS or user
+- usage of pivot root or creating a new root filesystem
+- other cgroup configuration such as pid limits
+
+### CLI/UX
+
+A user will interact with the job worker service via a CLI.
+
+#### Starting a job
+
+An example of running a command:
+
+```bash
+job-worker-client start \
+  -ca-cert-path /path/to/ca.crt \
+  -client-cert-path /path/to/client.crt \
+  -client-key-path /path/to/client.key \
+  -cpu 0.5 \
+  -memBytes 1000000000 \
+  -ioBytesPerSecond 1000000 \
+  /bin/bash -c "for ((i=0; i<100; i++)); do echo \"hello \$i\"; sleep 1; done"
+```
+
+
+which prints something like:
+
+```
+starting job <uuid>
+```
+
+Note: The `memBytes` flag is the maximum amount of memory to be used by the job. The example above sets the memory limit to 1GB.
+The `-cpu` flag is an appromixate number of CPU cores to limit the job to. The `-ioBytesPerSecond` limits read and write I/O
+operations to that number of bytes per second.
+
+The user must take note of the returned UUID to query the job's status, stream the job's output, or stop the job.
+
+#### Querying a job's status
+
+```bash
+job-worker-client status \
+  -ca-cert-path /path/to/ca.crt \
+  -client-cert-path /path/to/client.crt \
+  -client-key-path /path/to/client.key \
+  <uuid>
+```
+
+If the job is running then it prints something like:
+
+```
+status: running
+exit code: -1
+exit reason:
+```
+
+If the job has completed, then it prints something like:
+
+```
+status: complete
+exit code: 0
+exit reason:
+```
+
+If the job was killed, then it prints something like:
+
+```
+status: killed
+exit code: -1
+exit reason:
+```
+
+If the job failed to run, then it prints something like:
+
+```
+status: killed
+exit code: -1
+exit reason: exec: "not-a-command": executable file not found in $PATH
+```
+
+#### Streaming a job's output
+
+The `stream` command prints the entirety of the job's stdout and stderr combined to stdout from when the job started until
+current.
+
+```bash
+job-worker-client stream \
+  -ca-cert-path /path/to/ca.crt \
+  -client-cert-path /path/to/client.crt \
+  -client-key-path /path/to/client.key \
+  <uuid>
+```
+
+which prints the combined stdout and stderr of the process such as:
+
+```
+hello 0
+hello 1
+hello 2
+hello 3
+```
+
+The command will continue to print the output until the job completes or is killed.
+
+In the case that the job has completed, the command will print the output and then exit.
+
+#### Stopping a job
+
+```bash
+job-worker-client stop \
+  -ca-cert-path /path/to/ca.crt \
+  -client-cert-path /path/to/client.crt \
+  -client-key-path /path/to/client.key \
+  <uuid>
+```
+
+which prints something like:
+
+```
+job <uuid> stopped
+```
+
+### API
+
+The API is a gRPC service written in Golang. The API acts as a wrapper around the library to start, query, stream, and stop jobs.
+
+#### Security
+
+The client and API communicate via mTLS using TLS 1.3 as the minimum version. The following cipher suites are supported:
+
+- TLS_AES_128_GCM_SHA256
+- TLS_AES_256_GCM_SHA384
+- TLS_CHACHA20_POLY1305_SHA256
+
+Note: [Go does not support configuring supported cipher suites when using TLS 1.3](https://pkg.go.dev/crypto/tls#Config).
+
+#### Authorization
+
+The API treats the client's common name (CN) in the certificate as the user's identity.
+
+A client/user may not interact with a job not created by them in any way. No querying, streaming, or stopping of another user's job is allowed.
+
+#### Protobuf
+
+```proto
+syntax = "proto3";
+
+// ... options ...
+
+package jobworker;
+
+service JobWorker {
+  rpc Start(JobStartRequest) returns (Job) {}
+  rpc Query(Job) returns (JobStatus) {}
+  rpc Stream(Job) returns (stream Output) {}
+  rpc Stop(Job) returns (JobStopResponse) {}
+}
+
+message Job {
+  string id = 1;
+}
+
+message JobStartRequest {
+  double cpu = 1;
+  int64 mem_bytes = 2;
+  int64 io_bytes_per_second = 3;
+  string command = 4;
+  repeated string args = 5;
+}
+
+message JobStatus {
+  string status = 1;
+  int32 exit_code = 2;
+  string exit_reason = 3;
+}
+
+message Output {
+  bytes content = 1;
+}
+
+message JobStopResponse {}
+```
+
+### Library
+
+A library written in Golang supports running an arbitrary Linux process in isolation with resource limits.
+
+This library should know nothing about the client or API. It should be able to be used in any Golang program and treated as
+a public library.
+
+#### Process isolation
+
+The process is isolated by:
+- creating a new pid namespace to prevent a process from killing other processes running on the machine not created by the job
+- creating a new network namespace to prevent all receiving or sending network traffic both on the local network and internet
+- creating a new mount namespace which prevents modifying the host's mounts
+   - a new mount namespace also enables mounting a new proc filesystem that prevents the process from even seeing other processes on the host (e.g. `ps -ef`)
+
+#### Process resource limits
+
+The process's resources are limited by configuring cgroups. The user is expected to provide CPU, memory, and IO limits. cgroup v2 will be used by the library.
+
+#### Approximate Go doc
+
+The following describes types and functions that may exist in a new package for the library.
+
+##### type Job
+
+`Job` holds internal information about a job such as an [exec.Cmd](https://pkg.go.dev/os/exec#Cmd)  and process output.
+
+A `Job` should not be created directly. Instead, use the [New](#func-newconfig-jobconfig-job) function.
+
+#### type JobConfig
+
+```go
+type JobConfig struct {
+  JobExecutorPath  string
+  CPU              float64
+  MemBytes         int64
+  IOBytesPerSecond int64
+  Command          string
+  Arguments        []string
+}
+```
+
+`JobConfig` holds configuration for creating a new job. The fields are described in [New](#func-newconfig-jobconfig-job).
+
+All fields are required to be a non-zero value except `Arguments` to be able to successfully invoke [Job.Start](func-job-start-error).
+`Job.Start` will return an error if any of the fields are zero values.
+
+##### func New(config JobConfig) *Job
+
+`New` creates a new `Job`. No command is started until `Start` is invoked.
+
+It is expected that the config's `JobExecutorPath` is a binary that will execute the provided `Command` and `Arguments` similar to:
+
+```bash
+<JobExecutorPath> run /sys/fs/cgroup/<uuid>/tasks/cgroup.procs <Command> <Arguments>
+```
+
+It is expected that `JobExecutorPath` will add the pid of the process to the cgroup within `/sys/fs/cgroup/<uuid>/tasks/cgroup.procs`.
+
+> Note: `JobExecutorPath` may be a new binary entirely created from this design for the library to use. Eventually, it may make more
+> sense for the server binary to be a compatible `JobExecutorPath` that the library uses. This way to deploy the server requires only the one
+> server binary instead of the server binary and the `JobExecutorPath` binary. The server could provide `/proc/self/exe` to the library
+> as `JobExecutorPath`.
+
+The `JobExecutorPath` may seem odd, but this enables a "hook" to add the new process's PID to the cgroup before actually executing
+the desired command.
+
+##### func (*Job) Start() error
+
+`Start` creates a configured [exec.Cmd](https://pkg.go.dev/os/exec#Cmd).
+
+`Start` will return an error if the `Job` was provided a `JobConfig` with zero values for any of the fields, except `Arguments`.
+
+The configured `exec.Cmd` will isolate the process by setting clone and share flags for creating new mount, pid, and network namespaces.
+
+`Start` will also create a new cgroup for the job and set the CPU, memory, and IO limits. It will be up to the `jobExecutorPath` to append the PID to the cgroup's `cgroup.procs` file as described above.
+
+The configured `exec.Cmd` will execute `jobExecutorPath`. It is expected that `jobExecutorPath` is a binary that will do the following:
+
+- append the PID to the provided `cgroup.procs` file
+- mount a new proc filesystem
+- execute the provided `command` and `arguments`
+
+The `jobExecutorPath` will be executed similar to:
+
+```bash
+<jobExecutorPath> run /sys/fs/cgroup/<uuid>/tasks/cgroup.procs <command> <arguments>
+```
+
+Finally, `Start` runs the configured `exec.Cmd` in a new goroutine. `Start` does not wait for the command to complete. The goroutine will stop when the process completes or is killed. Once the process is completed (regardless of success), then the cgroups will be removed.
+
+It is an error to invoke `Start` on a `Job` that has already been started regardless of the job's status.
+
+##### func (*Job) Status() JobStatus
+
+`Status` returns the current status of the job. Refer to [JobStatus](#type-jobstatus) for more information.
+
+##### func (*Job) Stream(context.Context) <-chan []byte
+
+`Stream` returns a channel of the process's stdout and stderr output combined as it runs.
+
+Once the process has completed or terminated, the channel will be closed. Additionally, if the context is canceled, the channel will be closed.
+
+It is okay to call `Stream` for a job that has already been completed.
+
+It is okay to call `Stream` on a job that has not been started. The channel will remain open until the context is canceled or the job is eventually completed.
+
+##### func (*Job) Stop() error
+
+`Stop` will kill the process.
+
+Since the process is PID 1 in the new pid namespace, killing it will kill all other spawned process in the pid namespace.
+
+`Stop` will do nothing if the process has already completed or been killed.
+
+##### type JobStatus
+
+```go
+type JobStatus struct {
+  State     string
+  ExitCode  int
+  ExitReason string
+}
+```
+
+The `JobStatus` holds information about the job's status such as state, the exit code, and the exit reason.
+
+Exit code will be -1 if not in a completed state. Otherwise, it will be the process's exit code if process invoked exit. If the
+process was killed by a signal, then the exit code will be -1.
+
+Exit reason is populated with the error message returned by `exec.Cmd.Run` if the process failed to run.
+
+### Streaming considerations
+
+The API needs to be able to stream the process's output to multiple clients concurrently. Each client should receive the output
+from the start of the process regardless of when the client began streaming.
+
+The Job's `Stream` function will return a channel of the process's output. The Job needs to be able to identify in a performant
+manner when new output has been written and send that to each client.
+
+#### Proposed solution
+
+**Assume that the server has enough memory to hold all running jobs' stdout and stderr in memory.**
+
+A new type can be created that implements [io.Writer](https://pkg.go.dev/io#Writer) and [io.Closer](https://pkg.go.dev/io#Closer). This new type should be able to support multiple writers (a process's stdout and stderr) and multiple readers (multiple clients streaming the output).
+
+This new type will be provided as the job's stdout and stderr. This new type will then be closed by the job once the process has completed or been killed.
+
+This new type can store all process output in a `[]byte`. Consider a mutex to handle concurrent read/writes.
+
+The Job's `Stream` function will invoke this new type's `Stream` function. A new goroutine should be created per client that reads from the new type. The goroutine will track the last byte read and send all new bytes to the client. The goroutine should finish when
+this new type is closed and all bytes have been read or a provided context is canceled.
+
+To performantly know when new bytes have been added to the underlying content, consider using a
+[sync.Cond](https://pkg.go.dev/sync#Cond) to broadcast when new bytes have been written to the new type, so that each goroutine
+waiting for new bytes can be woken up to send the new bytes to their respective client.
+
+This new type should know nothing about the library, API, or client. This new type should not be treated as public and should exist
+within an `internal` directory to prevent any imports outside of this repository.
+
+### Test Plan
+
+Create a few end-to-end tests to verify some behaviors like:
+
+1. Demonstrate starting, checking the job's status, and stopping a job.
+1. Demonstrate starting a job, streaming the job output, and validating the stream completes when the process completes.
+1. Demonstrate a user may not interact with another user's job.
+1. Demonstrate a job may not make network requests.


### PR DESCRIPTION
This RFD lays out how to design a Linux job worker service for running arbitrary Linux processes with some degree of isolation and resource limits.

Users should be able to interact with the service via a CLI to start jobs, stop jobs, check status of jobs, and stream a job's output.